### PR TITLE
feat: Add configurable number of days to check

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ I am currently developing a VAE model for scRNASeq that enhances interpretabilit
 I am interested in causal inference, health data, cancer research"""
 # Maximum number of papers to process with LLM (set to 0 to disable LLM processing entirely)
 max_papers_for_llm = 100
+# Number of days to check for new papers (default is 7)
+days_to_check = 7
 
 [api]
 # Email address for CrossRef API requests (required for polite usage)

--- a/config_example.toml
+++ b/config_example.toml
@@ -16,6 +16,8 @@ I am currently developing a VAE model for scRNASeq that enhances interpretabilit
 I am interested in causal inference, health data, cancer research"""
 # Maximum number of papers to process with LLM (set to 0 to disable LLM processing entirely)
 max_papers_for_llm = 100
+# Number of days to check for new papers (default is 7)
+days_to_check = 7
 
 [api]
 # Email address for CrossRef API requests (required for polite usage)

--- a/crossref.py
+++ b/crossref.py
@@ -12,9 +12,12 @@ def fetch_crossref_data(query, config):
     Returns:
         tuple: (papers_with_abstracts dict, today date, last_week date)
     """
+    # Get the number of days to check from config, with a default of 7
+    days_to_check = config.get("search", {}).get("days_to_check", 7)
+
     # Calculate dynamic date range
     today = datetime.now().date()
-    last_week = today - timedelta(days=7)
+    last_week = today - timedelta(days=days_to_check)
     
     # Build query string by joining terms with space
     query_string = ' '.join(query)

--- a/nature.py
+++ b/nature.py
@@ -16,9 +16,12 @@ def fetch_nature_data(query, config):
     api_key = config.get('api', {}).get('springer_api_key', False)
     init(api_key=api_key)
     
+    # Get the number of days to check from config, with a default of 7
+    days_to_check = config.get("search", {}).get("days_to_check", 7)
+
     # Calculate dynamic date range
     today = datetime.now().date()
-    last_week = today - timedelta(days=7)
+    last_week = today - timedelta(days=days_to_check)
     
     # Format dates as strings
     date_from = last_week.strftime('%Y-%m-%d')


### PR DESCRIPTION
This commit introduces the ability to configure the number of days to look back for new papers.

- Adds a `days_to_check` parameter to the `[search]` section of the configuration file, with a default of 7 days.
- Updates `crossref.py` and `nature.py` to use this new configuration value.
- Updates `config_example.toml` and `README.md` to document the new feature.